### PR TITLE
refactor: replace raw go-redis with redis-ipc library

### DIFF
--- a/battery/battery_status.go
+++ b/battery/battery_status.go
@@ -2,8 +2,7 @@ package battery
 
 import (
 	"fmt"
-
-	"github.com/redis/go-redis/v9"
+	"strconv"
 )
 
 func (r *BatteryReader) parseStatusData(status0, status1, status2 []byte) {
@@ -131,38 +130,35 @@ func (r *BatteryReader) sendStatusUpdate() {
 	maxDelta := r.service.config.MaxVoltageDelta
 	if r.index > 0 && maxDelta > 0 && r.role == BatteryRoleActive && r.data.Present && !r.previousData.Present {
 		if r.data.Voltage > 0 {
-			v0, err := r.service.redis.HGet(r.ctx, "battery:0", "voltage").Uint64()
-			if err == nil && v0 > 0 {
-				v1 := uint64(r.data.Voltage)
-				var delta uint64
-				if v0 > v1 {
-					delta = v0 - v1
-				} else {
-					delta = v1 - v0
-				}
-				if delta > maxDelta {
-					r.logger.Warn(fmt.Sprintf("Voltage delta too large (%dmV > %dmV, battery0=%dmV, battery1=%dmV) - blocking battery 1 activation",
-						delta, maxDelta, v0, v1))
-					r.voltageDeltaBlocked = true
-					r.enabled = false
-				} else if r.voltageDeltaBlocked {
-					r.logger.Info(fmt.Sprintf("Voltage delta OK (%dmV <= %dmV) - unblocking battery 1",
-						delta, maxDelta))
-					r.voltageDeltaBlocked = false
-					r.enabled = true
+			v0str, err := r.service.ipc.HGet("battery:0", "voltage")
+			if err == nil {
+				v0, err := strconv.ParseUint(v0str, 10, 64)
+				if err == nil && v0 > 0 {
+					v1 := uint64(r.data.Voltage)
+					var delta uint64
+					if v0 > v1 {
+						delta = v0 - v1
+					} else {
+						delta = v1 - v0
+					}
+					if delta > maxDelta {
+						r.logger.Warn(fmt.Sprintf("Voltage delta too large (%dmV > %dmV, battery0=%dmV, battery1=%dmV) - blocking battery 1 activation",
+							delta, maxDelta, v0, v1))
+						r.voltageDeltaBlocked = true
+						r.enabled = false
+					} else if r.voltageDeltaBlocked {
+						r.logger.Info(fmt.Sprintf("Voltage delta OK (%dmV <= %dmV) - unblocking battery 1",
+							delta, maxDelta))
+						r.voltageDeltaBlocked = false
+						r.enabled = true
+					}
 				}
 			}
 		}
 	}
 
-	effectivePresent := r.data.Present
-
-	hashKey := fmt.Sprintf("battery:%d", r.index)
-	channel := fmt.Sprintf("battery:%d", r.index)
-
-	// Build fields map for all data
 	fields := map[string]any{
-		"present":            fmt.Sprintf("%v", effectivePresent),
+		"present":            fmt.Sprintf("%v", r.data.Present),
 		"state":              r.data.State.String(),
 		"voltage":            fmt.Sprintf("%d", r.data.Voltage),
 		"current":            fmt.Sprintf("%d", r.data.Current),
@@ -181,42 +177,15 @@ func (r *BatteryReader) sendStatusUpdate() {
 
 	if r.service.debug {
 		r.logger.Debug(fmt.Sprintf("Publishing state=%s, present=%v, voltage=%d, charge=%d",
-			r.data.State.String(), effectivePresent, r.data.Voltage, r.data.Charge))
+			r.data.State.String(), r.data.Present, r.data.Voltage, r.data.Charge))
 	}
 
-	// Use Redis transaction for atomic updates
-	pipe := r.service.redis.TxPipeline()
-
-	// Update all fields in Redis hash
-	pipe.HMSet(r.ctx, hashKey, fields)
-
-	// Update fault set within transaction
-	changedFaults, faultChanges := r.updateFaultSetInTransaction(pipe)
-
-	// Publish notifications for all changed fields
-	for field, value := range fields {
-		if value != r.previousFields[field] {
-			pipe.Publish(r.ctx, channel, field)
-		}
-	}
-
-	// Execute the transaction
-	if _, err := pipe.Exec(r.ctx); err != nil {
-		r.logger.Error(fmt.Sprintf("Failed to execute Redis transaction: %v", err))
+	// Publish hash fields (SetManyIfChanged handles change detection + PUBLISH)
+	if _, err := r.hashPub.SetManyIfChanged(fields); err != nil {
+		r.logger.Error(fmt.Sprintf("Failed to publish battery status: %v", err))
 		return
 	}
 
-	// Update fault tracking flags only after successful transaction
-	if faultChanges {
-		for _, fault := range changedFaults {
-			if state, exists := r.faultStates[fault]; exists {
-				state.PublishedToRedis = state.Present
-			}
-		}
-	}
-
-	// Update previous data for next comparison
-	r.previousFields = fields
 	r.previousData = r.data
 }
 
@@ -233,31 +202,3 @@ func (r *BatteryReader) temperatureStateString() string {
 	}
 }
 
-func (r *BatteryReader) updateFaultSetInTransaction(pipe redis.Pipeliner) ([]BMSFault, bool) {
-	faultKey := fmt.Sprintf("battery:%d:fault", r.index)
-	var changedFaults []BMSFault
-	anyChanges := false
-
-	for fault, state := range r.faultStates {
-		// Only update Redis if the fault state changed
-		if state.Present != state.PublishedToRedis {
-			if state.Present {
-				// Add fault to set
-				pipe.SAdd(r.ctx, faultKey, fmt.Sprintf("%d", fault))
-			} else {
-				// Remove fault from set
-				pipe.SRem(r.ctx, faultKey, fmt.Sprintf("%d", fault))
-			}
-			changedFaults = append(changedFaults, fault)
-			anyChanges = true
-		}
-	}
-
-	// Only publish fault notification if there were changes
-	if anyChanges {
-		faultChannel := fmt.Sprintf("battery:%d", r.index)
-		pipe.Publish(r.ctx, faultChannel, "fault")
-	}
-
-	return changedFaults, anyChanges
-}

--- a/battery/fault.go
+++ b/battery/fault.go
@@ -5,8 +5,6 @@ import (
 	"time"
 
 	"battery-service/battery/fsm"
-
-	"github.com/redis/go-redis/v9"
 )
 
 type FaultConfig struct {
@@ -164,46 +162,29 @@ func (r *BatteryReader) sendNotPresent() {
 
 func (r *BatteryReader) reportFault(fault BMSFault, config FaultConfig, present bool) {
 	batteryName := fmt.Sprintf("battery:%d", r.index)
-	faultSetKey := fmt.Sprintf("battery:%d:fault", r.index)
 
 	if present {
-		if err := r.service.redis.SAdd(r.ctx, faultSetKey, fmt.Sprintf("%d", fault)).Err(); err != nil {
+		if err := r.faultSet.Add(int(fault)); err != nil {
 			r.logger.Warn(fmt.Sprintf("Failed to add fault to set: %v", err))
 		}
 
-		if err := r.service.redis.XAdd(r.ctx, &redis.XAddArgs{
-			Stream: "events:faults",
-			MaxLen: 1000,
-			Values: map[string]any{
-				"group":       batteryName,
-				"code":        fmt.Sprintf("%d", fault),
-				"description": config.Description,
-			},
-		}).Err(); err != nil {
+		if _, err := r.faultStream.Add(map[string]any{
+			"group":       batteryName,
+			"code":        fmt.Sprintf("%d", fault),
+			"description": config.Description,
+		}); err != nil {
 			r.logger.Warn(fmt.Sprintf("Failed to add fault event to stream: %v", err))
 		}
-
-		if err := r.service.redis.Publish(r.ctx, batteryName, "fault").Err(); err != nil {
-			r.logger.Warn(fmt.Sprintf("Failed to publish fault notification: %v", err))
-		}
 	} else {
-		if err := r.service.redis.SRem(r.ctx, faultSetKey, fmt.Sprintf("%d", fault)).Err(); err != nil {
+		if err := r.faultSet.Remove(int(fault)); err != nil {
 			r.logger.Warn(fmt.Sprintf("Failed to remove fault from set: %v", err))
 		}
 
-		if err := r.service.redis.XAdd(r.ctx, &redis.XAddArgs{
-			Stream: "events:faults",
-			MaxLen: 1000,
-			Values: map[string]any{
-				"group": batteryName,
-				"code":  fmt.Sprintf("-%d", fault),
-			},
-		}).Err(); err != nil {
+		if _, err := r.faultStream.Add(map[string]any{
+			"group": batteryName,
+			"code":  fmt.Sprintf("-%d", fault),
+		}); err != nil {
 			r.logger.Warn(fmt.Sprintf("Failed to add fault clear event to stream: %v", err))
-		}
-
-		if err := r.service.redis.Publish(r.ctx, batteryName, "fault").Err(); err != nil {
-			r.logger.Warn(fmt.Sprintf("Failed to publish fault clear notification: %v", err))
 		}
 	}
 }

--- a/battery/reader.go
+++ b/battery/reader.go
@@ -38,6 +38,11 @@ func NewBatteryReader(index int, role BatteryRole, deviceName string, logLevel i
 
 	reader.logger = slog.New(NewFSMHandler(service.stdLogger.Writer(), LogLevel(logLevel), index))
 
+	batteryKey := fmt.Sprintf("battery:%d", index)
+	reader.hashPub = service.ipc.NewHashPublisher(batteryKey)
+	reader.faultSet = service.ipc.NewFaultSet(batteryKey+":fault", batteryKey, "fault")
+	reader.faultStream = service.ipc.NewStreamPublisher("events:faults")
+
 	var err error
 	reader.hal, err = hal.NewPN7150(deviceName, reader.makeLogCallback(), nil, true, false, service.debug)
 	if err != nil {
@@ -257,7 +262,7 @@ func (r *BatteryReader) SendSeatboxLockChange(closed bool) {
 func (r *BatteryReader) fetchInitialRedisState() {
 	r.logger.Debug("Fetching initial Redis state from hashes")
 
-	vehicleState, err := r.service.redis.HGet(r.ctx, "vehicle", "state").Result()
+	vehicleState, err := r.service.ipc.HGet("vehicle", "state")
 	if err == nil {
 		r.logger.Debug(fmt.Sprintf("Found vehicle state: %s", vehicleState))
 		r.handleVehicleStateChange(VehicleState(vehicleState))
@@ -265,7 +270,7 @@ func (r *BatteryReader) fetchInitialRedisState() {
 		r.logger.Warn(fmt.Sprintf("No vehicle state in Redis hash: %v", err))
 	}
 
-	seatboxLock, err := r.service.redis.HGet(r.ctx, "vehicle", "seatbox:lock").Result()
+	seatboxLock, err := r.service.ipc.HGet("vehicle", "seatbox:lock")
 	if err == nil {
 		closed := (seatboxLock == "closed")
 		r.logger.Debug(fmt.Sprintf("Found seatbox lock state: %s (closed=%t)", seatboxLock, closed))

--- a/battery/reader.go
+++ b/battery/reader.go
@@ -304,7 +304,7 @@ func (r *BatteryReader) makeLogCallback() hal.LogCallback {
 }
 
 func (r *BatteryReader) handleDeparture() {
-	r.data.Present = false
+	r.data = BMSData{Present: false}
 
 	// Cancel any pending fault timers to prevent activation after departure
 	r.faultMu.Lock()

--- a/battery/service.go
+++ b/battery/service.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/redis/go-redis/v9"
+	ipc "github.com/librescoot/redis-ipc"
 )
 
 func NewService(config *ServiceConfig, batteryConfig *BatteryConfiguration, logger *log.Logger, logLevel LogLevel, debugMode bool) (*Service, error) {
@@ -26,13 +26,16 @@ func NewService(config *ServiceConfig, batteryConfig *BatteryConfiguration, logg
 		readers:       make([]*BatteryReader, len(batteryConfig.Readers)),
 	}
 
-	s.redis = redis.NewClient(&redis.Options{
-		Addr: fmt.Sprintf("%s:%d", config.RedisServerAddress, config.RedisServerPort),
-	})
-
-	if err := s.redis.Ping(ctx).Err(); err != nil {
+	client, err := ipc.New(
+		ipc.WithAddress(config.RedisServerAddress),
+		ipc.WithPort(int(config.RedisServerPort)),
+		ipc.WithLogger(slog.New(NewServiceHandler(logger.Writer(), logLevel))),
+	)
+	if err != nil {
+		cancel()
 		return nil, fmt.Errorf("failed to connect to Redis: %v", err)
 	}
+	s.ipc = client
 
 	var activeReadersCreated bool
 	for i, readerConfig := range batteryConfig.Readers {
@@ -100,8 +103,8 @@ func (s *Service) Stop() {
 
 	wg.Wait()
 
-	if s.redis != nil {
-		s.redis.Close()
+	if s.ipc != nil {
+		s.ipc.Close()
 	}
 
 	s.logger.Info("Battery service stopped")
@@ -119,65 +122,49 @@ func (s *Service) SetBatteryEnabled(index int, enabled bool) error {
 func (s *Service) runRedisSubscriber() {
 	s.logger.Info("Starting Redis subscriber for channels: vehicle(state, seatbox:lock), settings")
 
-	pubsub := s.redis.Subscribe(s.ctx,
-		"vehicle",
-		"settings",
-	)
-	defer pubsub.Close()
+	vehicleWatcher := s.ipc.NewHashWatcher("vehicle")
+	vehicleWatcher.OnField("state", func(value string) error {
+		s.handleVehicleStateChange(value)
+		return nil
+	})
+	vehicleWatcher.OnField("seatbox:lock", func(value string) error {
+		s.handleSeatboxChange(value)
+		return nil
+	})
 
-	_, err := pubsub.Receive(s.ctx)
-	if err != nil {
-		s.logger.Error(fmt.Sprintf("Failed to establish Redis subscription: %v", err))
+	settingsWatcher := s.ipc.NewHashWatcher("settings")
+	settingsWatcher.OnField("scooter.battery-ignores-seatbox", func(value string) error {
+		s.handleIgnoreSeatboxSettingChange()
+		return nil
+	})
+	settingsWatcher.OnField("scooter.dual-battery", func(value string) error {
+		s.handleDualBatterySettingChange()
+		return nil
+	})
+	settingsWatcher.OnField("scooter.max-voltage-delta", func(value string) error {
+		s.handleMaxVoltageDeltaSettingChange()
+		return nil
+	})
+
+	if err := vehicleWatcher.Start(); err != nil {
+		s.logger.Error(fmt.Sprintf("Failed to start vehicle watcher: %v", err))
 		s.stdLogger.Fatal("Redis connection failed, exiting to allow systemd restart")
 	}
+	if err := settingsWatcher.Start(); err != nil {
+		s.logger.Error(fmt.Sprintf("Failed to start settings watcher: %v", err))
+		s.stdLogger.Fatal("Redis connection failed, exiting to allow systemd restart")
+	}
+
 	s.logger.Info("Redis subscription established successfully")
 
-	ch := pubsub.Channel()
-	s.logger.Debug("Listening for Redis messages...")
+	<-s.ctx.Done()
+	s.logger.Info("Redis subscriber context cancelled")
 
-	for {
-		select {
-		case msg := <-ch:
-			if msg == nil {
-				s.logger.Error("Redis channel closed unexpectedly")
-				s.stdLogger.Fatal("Redis connection lost, exiting to allow systemd restart")
-			}
-			s.logger.Debug(fmt.Sprintf("Received Redis message: channel=%s, payload=%s", msg.Channel, msg.Payload))
-
-			switch msg.Channel {
-			case "vehicle":
-				switch msg.Payload {
-				case "state":
-					s.handleVehicleStateMessage()
-				case "seatbox:lock":
-					s.handleSeatboxUpdate()
-				}
-			case "settings":
-				if msg.Payload == "scooter.battery-ignores-seatbox" {
-					s.handleIgnoreSeatboxSettingChange()
-				} else if msg.Payload == "scooter.dual-battery" {
-					s.handleDualBatterySettingChange()
-				} else if msg.Payload == "scooter.max-voltage-delta" {
-					s.handleMaxVoltageDeltaSettingChange()
-				}
-			default:
-				s.logger.Warn(fmt.Sprintf("Unknown Redis channel: %s", msg.Channel))
-			}
-
-		case <-s.ctx.Done():
-			s.logger.Info("Redis subscriber context cancelled")
-			return
-		}
-	}
+	vehicleWatcher.Stop()
+	settingsWatcher.Stop()
 }
 
-func (s *Service) handleVehicleStateMessage() {
-	vehicleState, err := s.redis.HGet(s.ctx, "vehicle", "state").Result()
-	if err != nil {
-		s.logger.Error(fmt.Sprintf("Failed to fetch vehicle state: %v", err))
-		return
-	}
-
+func (s *Service) handleVehicleStateChange(vehicleState string) {
 	newState := VehicleState(vehicleState)
 	s.logger.Info(fmt.Sprintf("Vehicle state changed: %s", newState))
 
@@ -190,13 +177,7 @@ func (s *Service) handleVehicleStateMessage() {
 	}
 }
 
-func (s *Service) handleSeatboxUpdate() {
-	seatboxLock, err := s.redis.HGet(s.ctx, "vehicle", "seatbox:lock").Result()
-	if err != nil {
-		s.logger.Error(fmt.Sprintf("Failed to fetch seatbox lock state: %v", err))
-		return
-	}
-
+func (s *Service) handleSeatboxChange(seatboxLock string) {
 	closed := (seatboxLock == "closed")
 	s.logger.Info(fmt.Sprintf("Seatbox lock changed: %s (closed=%t)", seatboxLock, closed))
 
@@ -208,9 +189,9 @@ func (s *Service) handleSeatboxUpdate() {
 }
 
 func (s *Service) loadIgnoreSeatboxSetting() {
-	setting, err := s.redis.HGet(s.ctx, "settings", "scooter.battery-ignores-seatbox").Result()
+	setting, err := s.ipc.HGet("settings", "scooter.battery-ignores-seatbox")
 	if err != nil {
-		if err != redis.Nil {
+		if err != ipc.ErrNil {
 			s.logger.Warn(fmt.Sprintf("Failed to load scooter.battery-ignores-seatbox setting: %v", err))
 		}
 		return
@@ -227,7 +208,7 @@ func (s *Service) loadIgnoreSeatboxSetting() {
 }
 
 func (s *Service) handleIgnoreSeatboxSettingChange() {
-	setting, err := s.redis.HGet(s.ctx, "settings", "scooter.battery-ignores-seatbox").Result()
+	setting, err := s.ipc.HGet("settings", "scooter.battery-ignores-seatbox")
 	if err != nil {
 		s.logger.Error(fmt.Sprintf("Failed to fetch scooter.battery-ignores-seatbox setting: %v", err))
 		return
@@ -247,16 +228,15 @@ func (s *Service) handleIgnoreSeatboxSettingChange() {
 	// Notify all active readers to re-evaluate their enabled state
 	for _, reader := range s.readers {
 		if reader != nil && reader.role == BatteryRoleActive {
-			// Trigger a restart to apply the new seatbox ignore setting
 			reader.triggerRestart()
 		}
 	}
 }
 
 func (s *Service) loadMaxVoltageDeltaSetting() {
-	setting, err := s.redis.HGet(s.ctx, "settings", "scooter.max-voltage-delta").Result()
+	setting, err := s.ipc.HGet("settings", "scooter.max-voltage-delta")
 	if err != nil {
-		if err != redis.Nil {
+		if err != ipc.ErrNil {
 			s.logger.Warn(fmt.Sprintf("Failed to load scooter.max-voltage-delta setting: %v", err))
 		}
 		return
@@ -273,7 +253,7 @@ func (s *Service) loadMaxVoltageDeltaSetting() {
 }
 
 func (s *Service) handleMaxVoltageDeltaSettingChange() {
-	setting, err := s.redis.HGet(s.ctx, "settings", "scooter.max-voltage-delta").Result()
+	setting, err := s.ipc.HGet("settings", "scooter.max-voltage-delta")
 	if err != nil {
 		s.logger.Error(fmt.Sprintf("Failed to fetch scooter.max-voltage-delta setting: %v", err))
 		return
@@ -290,21 +270,26 @@ func (s *Service) handleMaxVoltageDeltaSettingChange() {
 	s.logger.Info(fmt.Sprintf("Scooter max-voltage-delta setting changed: %d mV -> %d mV", oldValue, value))
 }
 
-// checkVoltageDelta reads both battery voltages from Redis and checks if the
-// difference is within acceptable limits. Returns true if the delta is OK or
-// if voltage data is unavailable (can't check). Also returns true if the
-// threshold is set to 0 (disabled).
 func (s *Service) checkVoltageDelta() (ok bool, delta uint64) {
 	maxDelta := s.config.MaxVoltageDelta
 	if maxDelta == 0 {
 		return true, 0
 	}
 
-	v0, err := s.redis.HGet(s.ctx, "battery:0", "voltage").Uint64()
+	v0str, err := s.ipc.HGet("battery:0", "voltage")
+	if err != nil {
+		return true, 0
+	}
+	v0, err := strconv.ParseUint(v0str, 10, 64)
 	if err != nil || v0 == 0 {
 		return true, 0
 	}
-	v1, err := s.redis.HGet(s.ctx, "battery:1", "voltage").Uint64()
+
+	v1str, err := s.ipc.HGet("battery:1", "voltage")
+	if err != nil {
+		return true, 0
+	}
+	v1, err := strconv.ParseUint(v1str, 10, 64)
 	if err != nil || v1 == 0 {
 		return true, 0
 	}
@@ -318,9 +303,9 @@ func (s *Service) checkVoltageDelta() (ok bool, delta uint64) {
 }
 
 func (s *Service) loadDualBatterySetting() {
-	setting, err := s.redis.HGet(s.ctx, "settings", "scooter.dual-battery").Result()
+	setting, err := s.ipc.HGet("settings", "scooter.dual-battery")
 	if err != nil {
-		if err != redis.Nil {
+		if err != ipc.ErrNil {
 			s.logger.Warn(fmt.Sprintf("Failed to load scooter.dual-battery setting: %v", err))
 		}
 		return
@@ -362,7 +347,7 @@ func (s *Service) loadDualBatterySetting() {
 }
 
 func (s *Service) handleDualBatterySettingChange() {
-	setting, err := s.redis.HGet(s.ctx, "settings", "scooter.dual-battery").Result()
+	setting, err := s.ipc.HGet("settings", "scooter.dual-battery")
 	if err != nil {
 		s.logger.Error(fmt.Sprintf("Failed to fetch scooter.dual-battery setting: %v", err))
 		return
@@ -409,14 +394,12 @@ func (s *Service) handleDualBatterySettingChange() {
 
 	// Update enabled state based on new role
 	if newRole == BatteryRoleInactive {
-		// Inactive batteries are always disabled
 		reader.SetEnabled(false)
 	} else {
-		// Active batteries follow seatbox state (unless ignoring seatbox)
 		if s.config.DangerouslyIgnoreSeatbox {
 			reader.SetEnabled(true)
 		} else {
-			seatboxLock, err := s.redis.HGet(s.ctx, "vehicle", "seatbox:lock").Result()
+			seatboxLock, err := s.ipc.HGet("vehicle", "seatbox:lock")
 			if err == nil {
 				closed := (seatboxLock == "closed")
 				reader.SetEnabled(closed)
@@ -424,6 +407,5 @@ func (s *Service) handleDualBatterySettingChange() {
 		}
 	}
 
-	// Trigger restart to apply the new role
 	reader.triggerRestart()
 }

--- a/battery/types.go
+++ b/battery/types.go
@@ -9,8 +9,7 @@ import (
 
 	"battery-service/battery/fsm"
 	"github.com/librescoot/pn7150"
-
-	"github.com/redis/go-redis/v9"
+	ipc "github.com/librescoot/redis-ipc"
 )
 
 type fsmStateMachine = fsm.StateMachine
@@ -196,7 +195,7 @@ type Service struct {
 	ctx           context.Context
 	cancel        context.CancelFunc
 	debug         bool
-	redis         *redis.Client
+	ipc           *ipc.Client
 	vehicleState  VehicleState
 	readers       []*BatteryReader
 }
@@ -222,9 +221,13 @@ type BatteryReader struct {
 	fsm          *fsmStateMachine
 	fsmCtx       context.Context
 	fsmCancel    context.CancelFunc
-	data           BMSData
-	previousData   BMSData
-	previousFields map[string]any
+	data         BMSData
+	previousData BMSData
+
+	// Redis IPC publishers
+	hashPub    *ipc.HashPublisher
+	faultSet   *ipc.FaultSet
+	faultStream *ipc.StreamPublisher
 
 	// Event loop control
 	stopChan    chan struct{}

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,13 @@ require (
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/librescoot/librefsm v0.4.0
 	github.com/librescoot/pn7150 v0.1.6
-	github.com/redis/go-redis/v9 v9.18.0
+	github.com/librescoot/redis-ipc v0.11.1
 )
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/redis/go-redis/v9 v9.18.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/librescoot/librefsm v0.4.0 h1:jZ65DBemEkw7ru6U+skDraAFW1Bzn17CXmZv76B
 github.com/librescoot/librefsm v0.4.0/go.mod h1:2fZNHRvoQMCPVgGbb31vgawzMaaPyazAPIgQRCiQ+Qw=
 github.com/librescoot/pn7150 v0.1.6 h1:VULFf2Y5YagHsd/9mVFssV3tmsnpxcKysxFYwAWmSl0=
 github.com/librescoot/pn7150 v0.1.6/go.mod h1:TO2zEBaw4rBSRx5exx+EFPpl9Gg3jKbc+gZEflfbPlM=
+github.com/librescoot/redis-ipc v0.11.1 h1:yEieCtJfXToqa/hqyFoR9N+2jg7WJNnrifDRJZCo/AE=
+github.com/librescoot/redis-ipc v0.11.1/go.mod h1:uvlJaUd1WzRMjZy7dYCHJ6qphCDeYD5orGK9CLudv1Q=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=


### PR DESCRIPTION
## Summary
- Replace direct `go-redis` calls with `redis-ipc` HashPublisher, FaultSet, StreamPublisher, and HashWatcher
- Eliminates manual HSET+PUBLISH pattern — HashPublisher handles change detection and notification atomically
- FaultSet.Add/Remove replaces raw SAdd/SRem+Publish for fault management
- StreamPublisher.Add replaces raw XAdd for fault event streaming
- HashWatcher replaces raw pubsub subscription loop for vehicle/settings state changes
- Net -85 lines; `go-redis` moves to indirect dependency

## Test plan
- [x] Deploy to Deep Blue, verify battery data appears in Redis (`redis-cli hgetall battery:0`)
- [x] Verify bluetooth-service receives all field updates (cycle-count, state-of-health, etc.)
- [ ] Test seatbox open/close triggers correct enable/disable behavior
- [ ] Test fault activation/clearing appears in fault set and event stream
- [ ] Verify dual-battery setting changes work correctly