### PR TITLE
feat: add keep-active-on-seatbox-open setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ To run the service:
 - `--debug`: Enable debug logging for detailed NCI/DATA messages
 - `--battery1-active`: Enable battery 1 as active in addition to battery 0 (default: inactive)
 - `--disable-battery1`: Disable battery 1 reader entirely
-- `--dangerously-ignore-seatbox`: Keep active batteries active when seatbox opens (DANGEROUS)
+- `--dangerously-ignore-seatbox`: Keep active batteries active when seatbox opens, suppress all seatbox events (DANGEROUS, legacy)
+- `--keep-active-on-seatbox-open`: Keep a running battery active across a seatbox open, but let seatbox events flow normally so asleep batteries go through the wake-up cycle and newly inserted batteries are detected without delay. Also settable at runtime via `settings.scooter.battery-keep-active-on-seatbox-open`.
 
 ## Logging
 

--- a/battery/actions.go
+++ b/battery/actions.go
@@ -187,3 +187,7 @@ func (r *BatteryReader) updateLastCmdTime() {
 func (r *BatteryReader) ShouldIgnoreSeatbox() bool {
 	return r.service.config.DangerouslyIgnoreSeatbox.Load()
 }
+
+func (r *BatteryReader) ShouldKeepActiveOnSeatboxOpen() bool {
+	return r.service.config.KeepActiveOnSeatboxOpen.Load()
+}

--- a/battery/actions.go
+++ b/battery/actions.go
@@ -189,5 +189,10 @@ func (r *BatteryReader) ShouldIgnoreSeatbox() bool {
 }
 
 func (r *BatteryReader) ShouldKeepActiveOnSeatboxOpen() bool {
+	// Inactive-role slots never run the keep-active path: the wake-up cycle
+	// lights the battery LED, which we don't want on a slot we're not driving.
+	if r.role != BatteryRoleActive {
+		return false
+	}
 	return r.service.config.KeepActiveOnSeatboxOpen.Load()
 }

--- a/battery/fsm/state_machine.go
+++ b/battery/fsm/state_machine.go
@@ -45,6 +45,7 @@ type BatteryActions interface {
 	ZeroRetryCounters()
 	StopHeartbeatTimer()
 	ShouldIgnoreSeatbox() bool
+	ShouldKeepActiveOnSeatboxOpen() bool
 	StartHeartbeatTimer()
 	ClearHeartbeatTimer()
 	StopTimerIfBatteryEmpty()
@@ -479,6 +480,12 @@ func buildDefinition(data *fsmData) *librefsm.Definition {
 					d.justOpened = true
 					return StateSendOpened
 				}
+				// With keep-active-on-seatbox-open, a running battery skips
+				// StateSendOff (which would deactivate it) and goes to heartbeat.
+				if d.actions.ShouldKeepActiveOnSeatboxOpen() {
+					d.justInserted = false
+					return StateHeartbeat
+				}
 				return StateSendOff
 			},
 			librefsm.WithParent(StateTagPresent),
@@ -585,7 +592,14 @@ func buildDefinition(data *fsmData) *librefsm.Definition {
 		Transition(StateWaitLastCmd, EvLastCmdTimeout, StateCondIgnoreSeatbox).
 
 		// Heartbeat transitions (apply to all heartbeat substates via hierarchy)
-		Transition(StateHeartbeat, EvSeatboxOpened, StateCondJustInserted).
+		// Guarded: with keep-active-on-seatbox-open, the event is absorbed and
+		// the battery keeps heartbeating across the seatbox open.
+		Transition(StateHeartbeat, EvSeatboxOpened, StateCondJustInserted,
+			librefsm.WithGuard(func(c *librefsm.Context) bool {
+				d := c.Data.(*fsmData)
+				return !d.actions.ShouldKeepActiveOnSeatboxOpen()
+			}),
+		).
 
 		// HeartbeatActions transitions
 		Transition(StateHeartbeatActions, EvHeartbeatTimeout, StateHeartbeat).
@@ -625,6 +639,21 @@ func buildDefinition(data *fsmData) *librefsm.Definition {
 			}),
 		).
 
+		// With keep-active-on-seatbox-open, break out of the seatbox-open
+		// maintenance loop into heartbeat after the wake-up cycle completes.
+		// The battery has now seen OFF -> OPENED -> INSERTED_IN_SCOOTER and
+		// is awake, so heartbeat can take over and send ON.
+		Transition(StateSendInsertedOpen, EvInsertedOpenTimeout, StateHeartbeat,
+			librefsm.WithGuard(func(c *librefsm.Context) bool {
+				d := c.Data.(*fsmData)
+				return d.actions.ShouldKeepActiveOnSeatboxOpen()
+			}),
+			librefsm.WithAction(func(c *librefsm.Context) error {
+				d := c.Data.(*fsmData)
+				d.justInserted = false
+				return nil
+			}),
+		).
 		Transition(StateSendInsertedOpen, EvInsertedOpenTimeout, StateSendOpened,
 			librefsm.WithAction(func(c *librefsm.Context) error {
 				d := c.Data.(*fsmData)

--- a/battery/reader.go
+++ b/battery/reader.go
@@ -167,14 +167,20 @@ func (r *BatteryReader) handleSeatboxLockChange(closed bool) {
 
 	if r.role == BatteryRoleActive {
 		var newEnabled bool
-		if r.voltageDeltaBlocked {
+		switch {
+		case r.voltageDeltaBlocked:
 			newEnabled = false
-		} else if r.service.config.DangerouslyIgnoreSeatbox.Load() {
+		case r.service.config.DangerouslyIgnoreSeatbox.Load():
 			newEnabled = true
 			if !closed {
 				r.logger.Warn("Seatbox opened but battery staying active (--dangerously-ignore-seatbox)")
 			}
-		} else {
+		case r.service.config.KeepActiveOnSeatboxOpen.Load():
+			newEnabled = true
+			if !closed {
+				r.logger.Info("Seatbox opened but battery staying active (keep-active-on-seatbox-open)")
+			}
+		default:
 			newEnabled = closed
 		}
 		if r.enabled != newEnabled {
@@ -196,7 +202,10 @@ func (r *BatteryReader) handleSeatboxLockChange(closed bool) {
 		r.latchedSeatboxLockClosed = false
 	}
 
-	if r.latchedSeatboxLockClosed != oldLatch && r.fsm.IsInState(fsm.StateTagPresent) {
+	// With keep-active-on-seatbox-open, don't restart a running battery on
+	// latch change; the FSM handles seatbox events directly and a restart
+	// would walk the battery through StateSendOff and briefly power it down.
+	if r.latchedSeatboxLockClosed != oldLatch && r.fsm.IsInState(fsm.StateTagPresent) && !r.service.config.KeepActiveOnSeatboxOpen.Load() {
 		r.logger.Debug(fmt.Sprintf("Latch changed (%t -> %t) and in StateTagPresent - triggering restart",
 			oldLatch, r.latchedSeatboxLockClosed))
 		r.triggerRestart()

--- a/battery/service.go
+++ b/battery/service.go
@@ -65,8 +65,13 @@ func (s *Service) Start() error {
 	s.logger.Info("Starting battery service")
 
 	s.loadBoolSetting(s.ignoreSeatboxSettingSpec())
+	s.loadBoolSetting(s.keepActiveOnSeatboxOpenSettingSpec())
 	s.loadUint64Setting(s.maxVoltageDeltaSettingSpec())
 	s.loadDualBatterySetting()
+
+	if s.config.DangerouslyIgnoreSeatbox.Load() && s.config.KeepActiveOnSeatboxOpen.Load() {
+		s.logger.Warn("Both dangerously-ignore-seatbox and keep-active-on-seatbox-open are set; dangerously-ignore-seatbox wins (superset)")
+	}
 
 	go s.runRedisSubscriber()
 
@@ -157,6 +162,8 @@ func (s *Service) runRedisSubscriber() {
 				switch msg.Payload {
 				case "scooter.battery-ignores-seatbox":
 					s.reloadBoolSetting(s.ignoreSeatboxSettingSpec())
+				case "scooter.battery-keep-active-on-seatbox-open":
+					s.reloadBoolSetting(s.keepActiveOnSeatboxOpenSettingSpec())
 				case "scooter.max-voltage-delta":
 					s.reloadUint64Setting(s.maxVoltageDeltaSettingSpec())
 				case "scooter.dual-battery":
@@ -329,12 +336,31 @@ func (s *Service) ignoreSeatboxSettingSpec() redisBoolSetting {
 		key:    "scooter.battery-ignores-seatbox",
 		target: &s.config.DangerouslyIgnoreSeatbox,
 		onChange: func(_, _ bool) {
-			for _, reader := range s.readers {
-				if reader != nil && reader.role == BatteryRoleActive {
-					reader.triggerRestart()
-				}
-			}
+			s.restartActiveReaders()
 		},
+	}
+}
+
+// keepActiveOnSeatboxOpenSettingSpec is the opt-in safer sibling of the
+// dangerously-ignore-seatbox flag. Reloading it deliberately restarts any
+// mid-cycle active reader so the new value takes effect at once, unlike the
+// latch-change restart suppression over in reader.go which protects a
+// running battery from being bounced through StateSendOff.
+func (s *Service) keepActiveOnSeatboxOpenSettingSpec() redisBoolSetting {
+	return redisBoolSetting{
+		key:    "scooter.battery-keep-active-on-seatbox-open",
+		target: &s.config.KeepActiveOnSeatboxOpen,
+		onChange: func(_, _ bool) {
+			s.restartActiveReaders()
+		},
+	}
+}
+
+func (s *Service) restartActiveReaders() {
+	for _, reader := range s.readers {
+		if reader != nil && reader.role == BatteryRoleActive {
+			reader.triggerRestart()
+		}
 	}
 }
 

--- a/battery/types.go
+++ b/battery/types.go
@@ -169,6 +169,7 @@ type ServiceConfig struct {
 	HeartbeatTimeout         time.Duration
 	OffUpdateTime            time.Duration
 	DangerouslyIgnoreSeatbox atomic.Bool
+	KeepActiveOnSeatboxOpen  atomic.Bool
 	MaxVoltageDelta          atomic.Uint64 // mV, 0 = disabled
 }
 

--- a/cmd/battery-service/main.go
+++ b/cmd/battery-service/main.go
@@ -36,7 +36,9 @@ func main() {
 	var debugMode bool
 	flag.BoolVar(&debugMode, "debug", false, "Enable debug logging for detailed NCI/DATA messages")
 	var dangerouslyIgnoreSeatbox bool
-	flag.BoolVar(&dangerouslyIgnoreSeatbox, "dangerously-ignore-seatbox", false, "Keep active batteries active when seatbox opens (DANGEROUS)")
+	flag.BoolVar(&dangerouslyIgnoreSeatbox, "dangerously-ignore-seatbox", false, "Keep active batteries active when seatbox opens, suppress all seatbox events (DANGEROUS, legacy)")
+	var keepActiveOnSeatboxOpen bool
+	flag.BoolVar(&keepActiveOnSeatboxOpen, "keep-active-on-seatbox-open", false, "Keep a running battery active across a seatbox open, but let seatbox events flow normally so asleep batteries go through the wake-up cycle and newly inserted batteries are detected without delay")
 
 	var device0, device1 string
 	var logLevel0, logLevel1 int
@@ -61,6 +63,7 @@ func main() {
 	config.HeartbeatTimeout = time.Duration(heartbeatTimeout) * time.Second
 	config.OffUpdateTime = time.Duration(offUpdateTime) * time.Second
 	config.DangerouslyIgnoreSeatbox.Store(dangerouslyIgnoreSeatbox)
+	config.KeepActiveOnSeatboxOpen.Store(keepActiveOnSeatboxOpen)
 	config.MaxVoltageDelta.Store(battery.DefaultMaxVoltageDeltaMV)
 
 	var stdLogger *log.Logger


### PR DESCRIPTION
## Summary

New opt-in setting that keeps a running battery powered across a seatbox open, without the downsides of `--dangerously-ignore-seatbox`. Exposed as a CLI flag (`--keep-active-on-seatbox-open`) and as a runtime-reloadable Redis setting (`scooter.battery-keep-active-on-seatbox-open`).

## Why

The existing `--dangerously-ignore-seatbox` mode works by suppressing seatbox events at the reader layer and bypassing the FSM's seatbox-lock check, jumping a just-inserted battery straight to `StateHeartbeat`. That's a problem when:

- A battery is moved from slot 1 to slot 0 (or any swap)
- A battery is inserted in sleep/off state

In both cases the BMS needs the normal `OFF` → `OPENED` → `INSERTED_IN_SCOOTER` command sequence to wake up. The old mode skips that sequence, so the battery doesn't respond to the `ON` command and it takes up to 40s to recover (or doesn't).

## What changes with the new flag

- Seatbox events still reach the FSM (not suppressed at the reader)
- A battery being inserted with the seatbox open goes through the normal wake-up loop (`StateSendOff`/`StateSendOpened`/`StateSendInsertedOpen`), then breaks out into `StateHeartbeat` via a guarded transition after one pass
- A battery that's already active when the seatbox opens stays in `StateHeartbeat`, because the `StateHeartbeat`/`EvSeatboxOpened` transition is guarded against the new flag and absorbed
- `StateCondOff` routes an already-active battery to `StateHeartbeat` directly instead of `StateSendOff`, so the activation path never deactivates a running battery
- The reader forces `enabled = true` on the active role (so heartbeat sends `ON` not `OFF`) and skips the latch-change `triggerRestart` so a running battery isn't bounced through `StateSendOff` on seatbox open

The old flag is untouched. If both flags are set, `--dangerously-ignore-seatbox` wins (strict superset) and a warning is logged at startup.

## Files touched

- `battery/types.go` — new `KeepActiveOnSeatboxOpen` field on `ServiceConfig`
- `cmd/battery-service/main.go` — new CLI flag
- `battery/service.go` — Redis setting load + hot-reload handler, precedence warning
- `battery/actions.go` — `ShouldKeepActiveOnSeatboxOpen()` accessor for the FSM
- `battery/fsm/state_machine.go` — interface method, `StateCondOff` branch, two guarded transitions
- `battery/reader.go` — switch cases in `handleSeatboxLockChange`, skip latch-change restart when the flag is on
- `README.md` — flag docs

## Test plan

- [x] Build passes for ARM and host
- [x] `go vet` clean
- [x] Deploy to Deep Blue with flag off, verify no behavioral change vs main
- [x] Enable `settings.scooter.battery-keep-active-on-seatbox-open` at runtime, verify reader triggers a restart and a running battery continues heartbeating across a seatbox open
- [x] Remove a battery from slot 1 and insert it into slot 0 with the flag on, verify the battery comes up without the 40s delay
- [x] Insert a fully asleep battery with the flag on, verify the wake-up cycle runs and heartbeat takes over
- [x] Toggle the flag off again at runtime, verify the next seatbox open deactivates the battery as before

## Follow-ups

- Extract the duplicated `loadXSetting`/`handleXSettingChange` boilerplate in `battery/service.go` (four near-identical pairs now)
- Synchronise concurrent access to hot-reloaded `ServiceConfig` flags (currently read/written across goroutines without a lock; pre-existing for `DangerouslyIgnoreSeatbox`)