### PR TITLE
chore: remove dangerously-ignore-seatbox flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ To run the service:
 - `--debug`: Enable debug logging for detailed NCI/DATA messages
 - `--battery1-active`: Enable battery 1 as active in addition to battery 0 (default: inactive)
 - `--disable-battery1`: Disable battery 1 reader entirely
-- `--dangerously-ignore-seatbox`: Keep active batteries active when seatbox opens, suppress all seatbox events (DANGEROUS, legacy)
 - `--keep-active-on-seatbox-open`: Keep a running battery active across a seatbox open, but let seatbox events flow normally so asleep batteries go through the wake-up cycle and newly inserted batteries are detected without delay. Also settable at runtime via `settings.scooter.battery-keep-active-on-seatbox-open`.
 
 ## Logging

--- a/battery/actions.go
+++ b/battery/actions.go
@@ -184,10 +184,6 @@ func (r *BatteryReader) updateLastCmdTime() {
 	r.lastCmdTime = time.Now()
 }
 
-func (r *BatteryReader) ShouldIgnoreSeatbox() bool {
-	return r.service.config.DangerouslyIgnoreSeatbox.Load()
-}
-
 func (r *BatteryReader) ShouldKeepActiveOnSeatboxOpen() bool {
 	// Inactive-role slots never run the keep-active path: the wake-up cycle
 	// lights the battery LED, which we don't want on a slot we're not driving.

--- a/battery/fsm/state.go
+++ b/battery/fsm/state.go
@@ -18,7 +18,6 @@ const (
 	StateCondCheckPresence  State = "cond_check_presence"
 	StateCheckPresence      State = "check_presence"
 	StateWaitLastCmd        State = "wait_last_cmd"
-	StateCondIgnoreSeatbox  State = "cond_ignore_seatbox"
 	StateCondSeatboxLock    State = "cond_seatbox_lock"
 	StateHeartbeat          State = "heartbeat"
 	StateHeartbeatActions   State = "heartbeat_actions"

--- a/battery/fsm/state_machine.go
+++ b/battery/fsm/state_machine.go
@@ -44,7 +44,6 @@ type BatteryActions interface {
 	IsInactive() bool
 	ZeroRetryCounters()
 	StopHeartbeatTimer()
-	ShouldIgnoreSeatbox() bool
 	ShouldKeepActiveOnSeatboxOpen() bool
 	StartHeartbeatTimer()
 	ClearHeartbeatTimer()
@@ -316,19 +315,6 @@ func buildDefinition(data *fsmData) *librefsm.Definition {
 			}),
 		).
 
-		// Condition: Ignore Seatbox - check if seatbox should be ignored
-		ConditionState(StateCondIgnoreSeatbox,
-			func(c *librefsm.Context) librefsm.StateID {
-				d := c.Data.(*fsmData)
-				if d.actions.ShouldIgnoreSeatbox() {
-					d.justInserted = false
-					return StateHeartbeat
-				}
-				return StateCondSeatboxLock
-			},
-			librefsm.WithParent(StateTagPresent),
-		).
-
 		// Condition: Seatbox Lock - check seatbox state
 		ConditionState(StateCondSeatboxLock,
 			func(c *librefsm.Context) librefsm.StateID {
@@ -589,7 +575,7 @@ func buildDefinition(data *fsmData) *librefsm.Definition {
 		Transition(StateCheckPresence, EvCheckPresenceTimeout, StateCondCheckPresence).
 
 		// Wait Last Cmd transitions
-		Transition(StateWaitLastCmd, EvLastCmdTimeout, StateCondIgnoreSeatbox).
+		Transition(StateWaitLastCmd, EvLastCmdTimeout, StateCondSeatboxLock).
 
 		// Heartbeat transitions (apply to all heartbeat substates via hierarchy)
 		// Guarded: with keep-active-on-seatbox-open, the event is absorbed and

--- a/battery/reader.go
+++ b/battery/reader.go
@@ -170,11 +170,6 @@ func (r *BatteryReader) handleSeatboxLockChange(closed bool) {
 		switch {
 		case r.voltageDeltaBlocked:
 			newEnabled = false
-		case r.service.config.DangerouslyIgnoreSeatbox.Load():
-			newEnabled = true
-			if !closed {
-				r.logger.Warn("Seatbox opened but battery staying active (--dangerously-ignore-seatbox)")
-			}
 		case r.service.config.KeepActiveOnSeatboxOpen.Load():
 			newEnabled = true
 			if !closed {
@@ -215,13 +210,10 @@ func (r *BatteryReader) handleSeatboxLockChange(closed bool) {
 		r.data.EmptyOr0Data = 0
 	}
 
-	// Only send seatbox events to FSM if not ignoring seatbox
-	if !r.service.config.DangerouslyIgnoreSeatbox.Load() {
-		if !closed && oldSeatboxLockClosed {
-			r.fsm.SendEvent(fsm.EvSeatboxOpened)
-		} else if closed && !oldSeatboxLockClosed {
-			r.fsm.SendEvent(fsm.EvSeatboxClosed)
-		}
+	if !closed && oldSeatboxLockClosed {
+		r.fsm.SendEvent(fsm.EvSeatboxOpened)
+	} else if closed && !oldSeatboxLockClosed {
+		r.fsm.SendEvent(fsm.EvSeatboxClosed)
 	}
 
 	r.checkInitComplete()

--- a/battery/service.go
+++ b/battery/service.go
@@ -64,14 +64,9 @@ func NewService(config *ServiceConfig, batteryConfig *BatteryConfiguration, logg
 func (s *Service) Start() error {
 	s.logger.Info("Starting battery service")
 
-	s.loadBoolSetting(s.ignoreSeatboxSettingSpec())
 	s.loadBoolSetting(s.keepActiveOnSeatboxOpenSettingSpec())
 	s.loadUint64Setting(s.maxVoltageDeltaSettingSpec())
 	s.loadDualBatterySetting()
-
-	if s.config.DangerouslyIgnoreSeatbox.Load() && s.config.KeepActiveOnSeatboxOpen.Load() {
-		s.logger.Warn("Both dangerously-ignore-seatbox and keep-active-on-seatbox-open are set; dangerously-ignore-seatbox wins (superset)")
-	}
 
 	s.loadInitialVehicleState()
 
@@ -162,8 +157,6 @@ func (s *Service) runRedisSubscriber() {
 				}
 			case "settings":
 				switch msg.Payload {
-				case "scooter.battery-ignores-seatbox":
-					s.reloadBoolSetting(s.ignoreSeatboxSettingSpec())
 				case "scooter.battery-keep-active-on-seatbox-open":
 					s.reloadBoolSetting(s.keepActiveOnSeatboxOpenSettingSpec())
 				case "scooter.max-voltage-delta":
@@ -367,21 +360,11 @@ func (s *Service) reloadUint64Setting(spec redisUint64Setting) {
 
 // ----- Setting specs -----
 
-func (s *Service) ignoreSeatboxSettingSpec() redisBoolSetting {
-	return redisBoolSetting{
-		key:    "scooter.battery-ignores-seatbox",
-		target: &s.config.DangerouslyIgnoreSeatbox,
-		onChange: func(_, _ bool) {
-			s.restartActiveReaders()
-		},
-	}
-}
-
-// keepActiveOnSeatboxOpenSettingSpec is the opt-in safer sibling of the
-// dangerously-ignore-seatbox flag. Reloading it deliberately restarts any
-// mid-cycle active reader so the new value takes effect at once, unlike the
-// latch-change restart suppression over in reader.go which protects a
-// running battery from being bounced through StateSendOff.
+// keepActiveOnSeatboxOpenSettingSpec keeps a running battery powered across
+// a seatbox open. Reloading deliberately restarts any mid-cycle active reader
+// so the new value takes effect at once, unlike the latch-change restart
+// suppression over in reader.go which protects a running battery from being
+// bounced through StateSendOff.
 func (s *Service) keepActiveOnSeatboxOpenSettingSpec() redisBoolSetting {
 	return redisBoolSetting{
 		key:    "scooter.battery-keep-active-on-seatbox-open",
@@ -529,16 +512,14 @@ func (s *Service) handleDualBatterySettingChange() {
 	if newRole == BatteryRoleInactive {
 		// Inactive batteries are always disabled
 		reader.SetEnabled(false)
+	} else if s.config.KeepActiveOnSeatboxOpen.Load() {
+		reader.SetEnabled(true)
 	} else {
-		// Active batteries follow seatbox state (unless ignoring seatbox)
-		if s.config.DangerouslyIgnoreSeatbox.Load() {
-			reader.SetEnabled(true)
-		} else {
-			seatboxLock, err := s.redis.HGet(s.ctx, "vehicle", "seatbox:lock").Result()
-			if err == nil {
-				closed := (seatboxLock == "closed")
-				reader.SetEnabled(closed)
-			}
+		// Active batteries follow seatbox state
+		seatboxLock, err := s.redis.HGet(s.ctx, "vehicle", "seatbox:lock").Result()
+		if err == nil {
+			closed := (seatboxLock == "closed")
+			reader.SetEnabled(closed)
 		}
 	}
 

--- a/battery/types.go
+++ b/battery/types.go
@@ -168,9 +168,8 @@ type ServiceConfig struct {
 	RedisServerPort          uint16
 	HeartbeatTimeout         time.Duration
 	OffUpdateTime            time.Duration
-	DangerouslyIgnoreSeatbox atomic.Bool
-	KeepActiveOnSeatboxOpen  atomic.Bool
-	MaxVoltageDelta          atomic.Uint64 // mV, 0 = disabled
+	KeepActiveOnSeatboxOpen atomic.Bool
+	MaxVoltageDelta         atomic.Uint64 // mV, 0 = disabled
 }
 
 type BatteryReaderConfig struct {

--- a/cmd/battery-service/main.go
+++ b/cmd/battery-service/main.go
@@ -35,8 +35,6 @@ func main() {
 	flag.UintVar(&offUpdateTime, "off-update-time", 1800, "Update time when disabled in seconds (30 minutes)")
 	var debugMode bool
 	flag.BoolVar(&debugMode, "debug", false, "Enable debug logging for detailed NCI/DATA messages")
-	var dangerouslyIgnoreSeatbox bool
-	flag.BoolVar(&dangerouslyIgnoreSeatbox, "dangerously-ignore-seatbox", false, "Keep active batteries active when seatbox opens, suppress all seatbox events (DANGEROUS, legacy)")
 	var keepActiveOnSeatboxOpen bool
 	flag.BoolVar(&keepActiveOnSeatboxOpen, "keep-active-on-seatbox-open", false, "Keep a running battery active across a seatbox open, but let seatbox events flow normally so asleep batteries go through the wake-up cycle and newly inserted batteries are detected without delay")
 
@@ -62,7 +60,6 @@ func main() {
 	config.RedisServerPort = uint16(redisPort)
 	config.HeartbeatTimeout = time.Duration(heartbeatTimeout) * time.Second
 	config.OffUpdateTime = time.Duration(offUpdateTime) * time.Second
-	config.DangerouslyIgnoreSeatbox.Store(dangerouslyIgnoreSeatbox)
 	config.KeepActiveOnSeatboxOpen.Store(keepActiveOnSeatboxOpen)
 	config.MaxVoltageDelta.Store(battery.DefaultMaxVoltageDeltaMV)
 


### PR DESCRIPTION
## Summary

Rip out `--dangerously-ignore-seatbox` and everything that wires it. `keep-active-on-seatbox-open` (merged in #13) covers the same user-facing need (keep the scooter running with the seatbox open) without the three real problems of the old flag:

1. It suppressed `EvSeatboxOpened`/`EvSeatboxClosed` at the reader layer, so the FSM never saw the event at all.
2. It short-circuited `StateCondIgnoreSeatbox` → `StateHeartbeat` on insertion, so an asleep or freshly-swapped battery skipped the BMS wake-up sequence (`OFF` → `OPENED` → `INSERTED_IN_SCOOTER`) and couldn't come up.
3. The consequence of (1) and (2) was an up-to-40-second insertion delay on every real-world battery swap.

Keeping both flags around meant every seatbox-related code path had to reason about two flags and a precedence rule, and the name was telegraphing that nobody should actually use the old one. Suggested in https://github.com/librescoot/battery-service/pull/13#issuecomment-4227378856 after some miles on Deep Blue with the new flag.

## What's removed

- `ServiceConfig.DangerouslyIgnoreSeatbox` (`atomic.Bool` field)
- `--dangerously-ignore-seatbox` CLI flag
- `scooter.battery-ignores-seatbox` Redis setting (load on startup and pub/sub reload dispatch)
- `ignoreSeatboxSettingSpec()` method and the "both flags set" precedence warning in `Start()`
- `ShouldIgnoreSeatbox()` from the FSM `BatteryActions` interface and `actions.go`
- `StateCondIgnoreSeatbox` between `StateWaitLastCmd` and `StateCondSeatboxLock` (the `EvLastCmdTimeout` transition now goes straight to `StateCondSeatboxLock`)
- The `reader.go` switch case for the old flag plus the event-forwarding suppression at `handleSeatboxLockChange`
- The `handleDualBatterySettingChange` branch now checks `KeepActiveOnSeatboxOpen` instead (same "force enabled on active role" semantics)
- README entry

## Compatibility

Deployed instances that still have the old Redis key set will silently ignore pub/sub notifications on it — the switch in `runRedisSubscriber` no longer has a case for `scooter.battery-ignores-seatbox`. Not a concern on Deep Blue where the key was `false` anyway.

## Size

`8 files changed, 19 insertions(+), 70 deletions(-)`. Net ~50 lines lighter.

## Test plan

- [x] `make build` (ARM) clean
- [x] `go vet ./...` clean
- [x] `go test ./...` clean (only `battery/fsm/constants_test.go` currently)
- [x] Deploy to Deep Blue, verify the service still starts and `keep-active-on-seatbox-open` still takes effect at runtime
- [x] Verify the FSM still walks a fresh insertion through `StateCondSeatboxLock` → `StateHeartbeat` with seatbox closed (the normal activation path shouldn't have changed)
- [x] Confirm no regressions to the slot 0 → slot 1 swap test from #13 (same test, keep-active-on-seatbox-open still on, no dangerously-ignore-seatbox to interact with)