### PR TITLE
fix: read initial vehicle and seatbox state from redis on startup

### DIFF
--- a/battery/service.go
+++ b/battery/service.go
@@ -73,6 +73,8 @@ func (s *Service) Start() error {
 		s.logger.Warn("Both dangerously-ignore-seatbox and keep-active-on-seatbox-open are set; dangerously-ignore-seatbox wins (superset)")
 	}
 
+	s.loadInitialVehicleState()
+
 	go s.runRedisSubscriber()
 
 	for _, reader := range s.readers {
@@ -176,6 +178,40 @@ func (s *Service) runRedisSubscriber() {
 		case <-s.ctx.Done():
 			s.logger.Info("Redis subscriber context cancelled")
 			return
+		}
+	}
+}
+
+// loadInitialVehicleState reads the vehicle state and seatbox lock from Redis
+// before the readers start, so each reader's init completes against real
+// values instead of the 5-second timeout fallback. Without this, a reader
+// waking up between vehicle-service publishes would default to
+// seatboxLockClosed=false, which is the "seatbox open" path and walks a fresh
+// tag through StateSendOff/StateSendOpened instead of straight to heartbeat.
+func (s *Service) loadInitialVehicleState() {
+	vehicleState := VehicleStateStandby
+	if raw, err := s.redis.HGet(s.ctx, "vehicle", "state").Result(); err == nil {
+		vehicleState = VehicleState(raw)
+	} else if err != redis.Nil {
+		s.logger.Warn(fmt.Sprintf("Failed to read initial vehicle state: %v", err))
+	}
+	s.vehicleState = vehicleState
+	s.logger.Info(fmt.Sprintf("Initial vehicle state: %s", vehicleState))
+
+	// Default to open (false) when the key is missing, matching the old
+	// 5-second init timeout behaviour so we stay on the conservative path.
+	seatboxClosed := false
+	if raw, err := s.redis.HGet(s.ctx, "vehicle", "seatbox:lock").Result(); err == nil {
+		seatboxClosed = (raw == "closed")
+	} else if err != redis.Nil {
+		s.logger.Warn(fmt.Sprintf("Failed to read initial seatbox lock state: %v", err))
+	}
+	s.logger.Info(fmt.Sprintf("Initial seatbox lock: closed=%t", seatboxClosed))
+
+	for _, reader := range s.readers {
+		if reader != nil {
+			reader.SendVehicleStateChange(vehicleState)
+			reader.SendSeatboxLockChange(seatboxClosed)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

On startup the reader defaulted `seatboxLockClosed` to `false` and only got its first correct value from a `vehicle` pub/sub publish. If nothing published in the first 5 seconds, a safety-net goroutine in `reader.Start()` forcibly completed init with `seatboxLockClosed=false`, which is the "seatbox open" activation path. A fresh tag discovery then walked through `StateSendOff` → `StateSendOpened` → `StateSendInsertedOpen` and parked there indefinitely, until some later pub/sub update triggered a restart.

Observed during the #14 removal test on Deep Blue: I restarted `librescoot-battery`, Battery 0 came up and started running, then I toggled `scooter.battery-keep-active-on-seatbox-open` off. That triggered a restart, Battery 0 walked through the stale "seatbox open" path, and got stuck in the `send_opened` ↔ `send_inserted_open` loop. A later manual `redis-cli publish vehicle seatbox:lock` updated the reader's field but didn't break it out because the enabled-change path didn't fire (enabled was already true) and the latch-change restart fired too late or got absorbed somewhere. Only another `keep-active` toggle eventually shook it loose.

## Fix

Add `loadInitialVehicleState()` in `battery/service.go`:

- Runs during `Start()`, after settings load and before `runRedisSubscriber` / `reader.Start()`
- Does a synchronous `HGet` on `vehicle.state` and `vehicle.seatbox:lock`
- Logs what it found
- Pushes the values through the existing `SendVehicleStateChange` / `SendSeatboxLockChange` channels. These are `tryUpdateChannel`-based size-1 buffers, so values sit there until each reader's event loop drains them on its first iteration, and `checkInitComplete` fires naturally against real state

Defaults match the old 5-second timeout fallback (`VehicleStateStandby`, `seatboxClosed=false`) for the edge case where `vehicle-service` hasn't populated the keys yet — conservative, no difference from today.

## Test plan

- [x] `make build` clean
- [x] `go vet ./...` clean
- [ ] Deploy to Deep Blue, verify startup log shows `Initial vehicle state: ...` and `Initial seatbox lock: closed=...`
- [ ] Verify no more "Initialization timeout, forcing start with defaults" warnings when Redis has the keys populated
- [ ] Restart the service and immediately toggle `keep-active-on-seatbox-open`; Battery 0 should restart cleanly into heartbeat instead of stalling in the seatbox-open loop

## Files changed

`battery/service.go` (+36 lines, one new method and one call from `Start`)