### PR TITLE
chore: honour deprecated scooter.battery-ignores-seatbox as alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ To run the service:
 - `--disable-battery1`: Disable battery 1 reader entirely
 - `--keep-active-on-seatbox-open`: Keep a running battery active across a seatbox open, but let seatbox events flow normally so asleep batteries go through the wake-up cycle and newly inserted batteries are detected without delay. Also settable at runtime via `settings.scooter.battery-keep-active-on-seatbox-open`.
 
+The legacy `settings.scooter.battery-ignores-seatbox` key is still honoured as a deprecated alias for `settings.scooter.battery-keep-active-on-seatbox-open`. The old `--dangerously-ignore-seatbox` CLI flag and its distinct FSM-bypass semantics are gone; the alias just sets the modern flag and logs a deprecation warning. If both keys are set in Redis, the modern key wins.
+
 ## Logging
 
 The service utilizes a leveled logging system. You can control the verbosity of the logs using the `--log` command-line option for the entire service, or `--log0` and `--log1` for individual battery readers. The log levels are:

--- a/battery/service.go
+++ b/battery/service.go
@@ -64,6 +64,9 @@ func NewService(config *ServiceConfig, batteryConfig *BatteryConfiguration, logg
 func (s *Service) Start() error {
 	s.logger.Info("Starting battery service")
 
+	// Deprecated alias: if the old key is set, seed KeepActiveOnSeatboxOpen
+	// from it (and warn). The real setting below wins if both are present.
+	s.loadDeprecatedIgnoreSeatboxSetting()
 	s.loadBoolSetting(s.keepActiveOnSeatboxOpenSettingSpec())
 	s.loadUint64Setting(s.maxVoltageDeltaSettingSpec())
 	s.loadDualBatterySetting()
@@ -159,6 +162,8 @@ func (s *Service) runRedisSubscriber() {
 				switch msg.Payload {
 				case "scooter.battery-keep-active-on-seatbox-open":
 					s.reloadBoolSetting(s.keepActiveOnSeatboxOpenSettingSpec())
+				case "scooter.battery-ignores-seatbox":
+					s.handleDeprecatedIgnoreSeatboxChange()
 				case "scooter.max-voltage-delta":
 					s.reloadUint64Setting(s.maxVoltageDeltaSettingSpec())
 				case "scooter.dual-battery":
@@ -373,6 +378,45 @@ func (s *Service) keepActiveOnSeatboxOpenSettingSpec() redisBoolSetting {
 			s.restartActiveReaders()
 		},
 	}
+}
+
+// loadDeprecatedIgnoreSeatboxSetting handles the legacy
+// scooter.battery-ignores-seatbox Redis key. The old flag's full semantics
+// (suppressing seatbox events at the reader, bypassing the FSM's wake-up
+// sequence) were removed in #14, but deployed instances may still have the
+// key set. We treat it as an alias for the safer
+// scooter.battery-keep-active-on-seatbox-open flag and log a deprecation
+// warning so callers migrate. Called before the real setting loads, so the
+// real setting wins if both are present.
+func (s *Service) loadDeprecatedIgnoreSeatboxSetting() {
+	raw, err := s.redis.HGet(s.ctx, "settings", "scooter.battery-ignores-seatbox").Result()
+	if err != nil {
+		if err != redis.Nil {
+			s.logger.Warn(fmt.Sprintf("Failed to load deprecated scooter.battery-ignores-seatbox setting: %v", err))
+		}
+		return
+	}
+	value, ok := parseBoolSetting(raw)
+	if !ok {
+		s.logger.Warn(fmt.Sprintf("Invalid scooter.battery-ignores-seatbox value: %q (must be 'true' or 'false')", raw))
+		return
+	}
+	s.logger.Warn(fmt.Sprintf("Setting 'scooter.battery-ignores-seatbox=%t' is deprecated; treating as alias for 'scooter.battery-keep-active-on-seatbox-open'. Please migrate.", value))
+	s.config.KeepActiveOnSeatboxOpen.Store(value)
+}
+
+// handleDeprecatedIgnoreSeatboxChange reloads the deprecated alias key into
+// the KeepActiveOnSeatboxOpen target when a pub/sub notification arrives on
+// the old channel, logging a deprecation warning each time.
+func (s *Service) handleDeprecatedIgnoreSeatboxChange() {
+	s.logger.Warn("Received pub/sub for deprecated 'scooter.battery-ignores-seatbox'; still treating as alias for 'scooter.battery-keep-active-on-seatbox-open'. Please migrate.")
+	s.reloadBoolSetting(redisBoolSetting{
+		key:    "scooter.battery-ignores-seatbox",
+		target: &s.config.KeepActiveOnSeatboxOpen,
+		onChange: func(_, _ bool) {
+			s.restartActiveReaders()
+		},
+	})
 }
 
 func (s *Service) restartActiveReaders() {


### PR DESCRIPTION
## Summary

#14 removed the `scooter.battery-ignores-seatbox` Redis setting entirely, along with the `--dangerously-ignore-seatbox` CLI flag. Deployed instances that still have the old key set lose their effect on upgrade — the switch in `runRedisSubscriber` no longer has a case for it, and `Start()` doesn't load it. On Deep Blue the key was already `false` so there was no real concern, but other deployments could end up with a silent behaviour change.

This treats the old key as a deprecated alias for `scooter.battery-keep-active-on-seatbox-open`, which — as the PR #14 description itself says — covers the same user-facing need ("keep the scooter running with the seatbox open"). The alias just writes the modern flag's atomic and logs a deprecation warning so operators can migrate.

Note the two flags were not semantically identical. The old one also suppressed `EvSeatboxOpened`/`EvSeatboxClosed` at the reader layer and short-circuited `StateCondIgnoreSeatbox` → `StateHeartbeat` on insertion — which were the BMS-wake-up and 40-second-insertion-delay bugs that motivated the removal. The alias deliberately does *not* bring any of that back. Operators who were relying on the old semantics (vs just the name) will notice no change beyond the deprecation warning, because #14 already removed them.

## Behaviour

- `Start()` calls `loadDeprecatedIgnoreSeatboxSetting()` before `loadBoolSetting(keepActiveOnSeatboxOpenSettingSpec())`. If the old key is present, it seeds `KeepActiveOnSeatboxOpen` and logs a warning. The real key loads next and wins if both are set.
- `runRedisSubscriber` dispatches notifications on `scooter.battery-ignores-seatbox` to `handleDeprecatedIgnoreSeatboxChange()`, which reloads the alias into `KeepActiveOnSeatboxOpen` and logs a deprecation warning each time.
- No new config fields, no FSM changes, no reader changes.

## Files touched

- `battery/service.go` — `loadDeprecatedIgnoreSeatboxSetting()`, `handleDeprecatedIgnoreSeatboxChange()`, wiring in `Start()` and the subscriber switch.
- `README.md` — note the alias and the "modern key wins" precedence.

## Test plan

- [x] `GOTOOLCHAIN=go1.25.7 go build ./...` clean
- [x] `GOTOOLCHAIN=go1.25.7 go vet ./...` clean
- [x] `make build` (ARM) clean
- [ ] Deploy to Deep Blue with only the old key set, verify `scooter.battery-keep-active-on-seatbox-open` behaviour kicks in and the deprecation warning appears in the journal
- [ ] Toggle `settings.scooter.battery-ignores-seatbox` at runtime, verify the subscriber warning fires and the modern flag follows
- [ ] Set both keys with opposing values, verify the modern key wins